### PR TITLE
API improvements

### DIFF
--- a/examples/test.sh
+++ b/examples/test.sh
@@ -29,12 +29,20 @@ function kill-server {
     netstat -tlp 2>/dev/null | awk '{ if ($4 == "*:8000") { split($7, pid, /\//); print pid[1] } }' | xargs -r kill -KILL
 }
 
-# Sends a transaction to the cryptocurrency demo.
+# Creates a wallet in the cryptocurrency demo.
 #
 # Arguments:
 # - $1: filename with the transaction data
-function send-transaction {
-    RESP=`curl -H "Content-Type: application/json" -X POST -d @$1 http://127.0.0.1:8000/api/services/cryptocurrency/v1/wallets/transaction 2>/dev/null`
+function create-wallet {
+    RESP=`curl -H "Content-Type: application/json" -X POST -d @$1 http://127.0.0.1:8000/api/services/cryptocurrency/v1/wallets 2>/dev/null`
+}
+
+# Performs a transfer in the cryptocurrency demo.
+#
+# Arguments:
+# - $1: filename with the transaction data
+function transfer {
+    RESP=`curl -H "Content-Type: application/json" -X POST -d @$1 http://127.0.0.1:8000/api/services/cryptocurrency/v1/wallets/transfer 2>/dev/null`
 }
 
 # Checks a response to an Exonum transaction.
@@ -106,15 +114,15 @@ kill-server
 launch-server
 
 echo "Creating a wallet for Johnny..."
-send-transaction create-wallet-1.json
+create-wallet create-wallet-1.json
 check-transaction 44c6c2c5
 
 echo "Creating a wallet for Janie..."
-send-transaction create-wallet-2.json
+create-wallet create-wallet-2.json
 check-transaction 8714e906
 
 echo "Transferring funds from Johnny to Janie"
-send-transaction transfer-funds.json
+transfer transfer-funds.json
 check-transaction e63b28ca
 
 echo "Waiting until transactions are committed..."

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,12 @@ struct CryptocurrencyApi {
     blockchain: Blockchain,
 }
 
+/// The structure returned by the REST API.
+#[derive(Serialize, Deserialize)]
+struct TransactionResponse {
+    tx_hash: Hash,
+}
+
 /// Shortcut to get data on wallets.
 impl CryptocurrencyApi {
     /// Endpoint for getting a single wallet.
@@ -258,31 +264,6 @@ impl CryptocurrencyApi {
     }
 }
 
-/// Add an enum which joins transactions of both types to simplify request
-/// processing.
-#[serde(untagged)]
-#[derive(Clone, Serialize, Deserialize)]
-enum TransactionRequest {
-    CreateWallet(TxCreateWallet),
-    Transfer(TxTransfer),
-}
-
-/// Implement a trait for the enum for deserialized `TransactionRequest`s
-/// to fit into the node channel.
-impl Into<Box<Transaction>> for TransactionRequest {
-    fn into(self) -> Box<Transaction> {
-        match self {
-            TransactionRequest::CreateWallet(trans) => Box::new(trans),
-            TransactionRequest::Transfer(trans) => Box::new(trans),
-        }
-    }
-}
-
-/// The structure returned by the REST API.
-#[derive(Serialize, Deserialize)]
-struct TransactionResponse {
-    tx_hash: Hash,
-}
 
 /// Implement the `Api` trait.
 /// `Api` facilitates conversion between transactions/read requests and REST

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,9 +59,10 @@ const INIT_BALANCE: u64 = 100;
 // Declare the data to be stored in the blockchain. In the present case,
 // declare a type for storing information about the wallet and its balance.
 
-/// Declare a [serializable][1]
-/// [1]: https://github.com/exonum/exonum-doc/blob/master/src/architecture/serialization.md
-/// struct and determine bounds of its fields with `encoding_struct!` macro.
+/// Declare a [serializable][1] struct and determine bounds of its fields
+/// with `encoding_struct!` macro.
+///
+/// [1]: https://exonum.com/doc/architecture/serialization
 encoding_struct! {
     struct Wallet {
         const SIZE = 48;
@@ -93,12 +94,13 @@ pub struct CurrencySchema<'a> {
     view: &'a mut Fork,
 }
 
-/// Declare layout of the data. Use an instance of [`MapIndex`][2]
-/// [2]: https://github.com/exonum/exonum-doc/blob/master/src/architecture/storage.md#mapindex
+/// Declare layout of the data. Use an instance of [`MapIndex`]
 /// to keep wallets in storage. Index values are serialized `Wallet` structs.
 ///
 /// Isolate the wallets map into a separate entity by adding a unique prefix,
 /// i.e. the first argument to the `MapIndex::new` call.
+///
+/// [`MapIndex`]: https://exonum.com/doc/architecture/storage#mapindex
 impl<'a> CurrencySchema<'a> {
     pub fn wallets(&mut self) -> MapIndex<&mut Fork, PublicKey, Wallet> {
         MapIndex::new("cryptocurrency.wallets", self.view)

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,16 +215,12 @@ impl CryptocurrencyApi {
         schema.wallet(pub_key)
     }
 
-    fn get_wallets(&self) -> Option<Vec<Wallet>> {
+    fn get_wallets(&self) -> Vec<Wallet> {
         let mut view = self.blockchain.fork();
         let mut schema = CurrencySchema { view: &mut view };
         let idx = schema.wallets();
         let wallets: Vec<Wallet> = idx.values().collect();
-        if wallets.is_empty() {
-            None
-        } else {
-            Some(wallets)
-        }
+        wallets
     }
 }
 
@@ -278,14 +274,8 @@ impl Api for CryptocurrencyApi {
         // Gets status of all wallets.
         let self_ = self.clone();
         let wallets_info = move |_: &mut Request| -> IronResult<Response> {
-            if let Some(wallets) = self_.get_wallets() {
-                self_.ok_response(&serde_json::to_value(wallets).unwrap())
-            } else {
-                self_.not_found_response(
-                    &serde_json::to_value("Wallets database is empty")
-                        .unwrap(),
-                )
-            }
+            let wallets = self_.get_wallets();
+            self_.ok_response(&serde_json::to_value(&wallets).unwrap())
         };
 
         // Gets status of the wallet corresponding to the public key.


### PR DESCRIPTION
This PR improves the API handling in the tutorial as follows:

- `POST` endpoints are separated; correspondingly, `enum TransactionRequest` and some related code becomes obsolete and is removed. Motivation: it seems very unusual to me to combine unrelated actions into a single endpoint; I have not seen convincing examples of doing so (there are cases of batch requests and the like, but they seem not applicable).
- `GET /wallets` always returns an OK status. Motivation: 0 wallets is a valid response to the request; I see no reasons why this case should be handled specially.
- Endpoint processing is moved from the `Api.wire()` into separate methods in `impl Api { .. }`. Motivation: easier to read separate methods than a bunch of closures in a single method.

Note that if the `Api` trait had a method like `fn api_sender(&self) -> &ApiSender`, `post_transaction` could probably be moved to the `Api` interface as a provided method.