### PR TITLE
Test transaction business logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "exonum 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-testkit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -841,6 +842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rayon"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1426,7 @@ dependencies = [
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
 "checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 exonum-testkit = "0.1.1"
+rand = "0.4"

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! These are tests concerning the API of the cryptocurrency service. See `tx_logic.rs`
+//! for tests focused on the business logic of transactions.
+//!
+//! Note how API tests predominantly use `TestKitApi` to send transactions and make assertions
+//! about the storage state.
+
 extern crate exonum;
 extern crate exonum_cryptocurrency as cryptocurrency;
 extern crate exonum_testkit;

--- a/tests/tx_logic.rs
+++ b/tests/tx_logic.rs
@@ -33,7 +33,6 @@ use cryptocurrency::{CurrencySchema, CurrencyService, TxCreateWallet, TxTransfer
 
 fn init_testkit() -> TestKit {
     TestKitBuilder::validator()
-        .with_validators(4)
         .with_service(CurrencyService)
         .create()
 }
@@ -78,7 +77,7 @@ fn test_transfer() {
         assert_eq!(alice_wallet.balance(), 90);
         assert_eq!(bob_wallet.balance(), 110);
     } else {
-        panic!("Wallets not persisted")
+        panic!("Wallets not persisted");
     }
 }
 
@@ -100,7 +99,7 @@ fn test_transfer_from_nonexisting_wallet() {
     if let (None, Some(bob_wallet)) = wallets {
         assert_eq!(bob_wallet.balance(), 100);
     } else {
-        panic!("Wallets not persisted")
+        panic!("Wallets not persisted");
     }
 }
 
@@ -125,7 +124,7 @@ fn test_transfer_to_nonexisting_wallet() {
         assert_eq!(alice_wallet.balance(), 100);
         assert_eq!(bob_wallet.balance(), 100);
     } else {
-        panic!("Wallets not persisted")
+        panic!("Wallets not persisted");
     }
 }
 
@@ -151,7 +150,7 @@ fn test_transfer_overcharge() {
         assert_eq!(alice_wallet.balance(), 100);
         assert_eq!(bob_wallet.balance(), 100);
     } else {
-        panic!("Wallets not persisted")
+        panic!("Wallets not persisted");
     }
 }
 

--- a/tests/tx_logic.rs
+++ b/tests/tx_logic.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! These are tests concerning the business logic of transactions in the cryptocurrency service.
+//! See `api.rs` for tests focused on the API of the service.
+//!
+//! Note how business logic tests use `TestKit::create_block*` methods to send transactions,
+//! the service schema to make assertions about the storage state.
+
 extern crate exonum;
 extern crate exonum_cryptocurrency as cryptocurrency;
 #[macro_use]

--- a/tests/tx_logic.rs
+++ b/tests/tx_logic.rs
@@ -1,0 +1,246 @@
+// Copyright 2017 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate exonum;
+extern crate exonum_cryptocurrency as cryptocurrency;
+#[macro_use]
+extern crate exonum_testkit;
+extern crate rand;
+
+use exonum::blockchain::Transaction;
+use exonum::crypto;
+use exonum_testkit::{TestKit, TestKitBuilder};
+
+// Import datatypes used in tests from the crate where the service is defined.
+use cryptocurrency::{CurrencySchema, CurrencyService, TxCreateWallet, TxTransfer, Wallet};
+
+fn init_testkit() -> TestKit {
+    TestKitBuilder::validator()
+        .with_validators(4)
+        .with_service(CurrencyService)
+        .create()
+}
+
+#[test]
+fn test_create_wallet() {
+    let mut testkit = init_testkit();
+    let (pubkey, key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&pubkey, "Alice", &key),
+    ]);
+
+    // Check that the user indeed is persisted by the service
+    let wallet = {
+        let snapshot = testkit.snapshot();
+        CurrencySchema::new(&snapshot).wallet(&pubkey).expect(
+            "No wallet persisted",
+        )
+    };
+    assert_eq!(*wallet.pub_key(), pubkey);
+    assert_eq!(wallet.name(), "Alice");
+    assert_eq!(wallet.balance(), 100);
+}
+
+#[test]
+fn test_transfer() {
+    let mut testkit = init_testkit();
+    let (alice_pubkey, alice_key) = crypto::gen_keypair();
+    let (bob_pubkey, bob_key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&alice_pubkey, "Alice", &alice_key),
+        TxCreateWallet::new(&bob_pubkey, "Bob", &bob_key),
+        TxTransfer::new(&alice_pubkey, &bob_pubkey, /* amount */ 10, /* seed */ 0, &alice_key),
+    ]);
+
+    let wallets = {
+        let snapshot = testkit.snapshot();
+        let schema = CurrencySchema::new(&snapshot);
+        (schema.wallet(&alice_pubkey), schema.wallet(&bob_pubkey))
+    };
+    if let (Some(alice_wallet), Some(bob_wallet)) = wallets {
+        assert_eq!(alice_wallet.balance(), 90);
+        assert_eq!(bob_wallet.balance(), 110);
+    } else {
+        panic!("Wallets not persisted")
+    }
+}
+
+#[test]
+fn test_transfer_from_nonexisting_wallet() {
+    let mut testkit = init_testkit();
+    let (alice_pubkey, alice_key) = crypto::gen_keypair();
+    let (bob_pubkey, bob_key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&bob_pubkey, "Bob", &bob_key),
+        TxTransfer::new(&alice_pubkey, &bob_pubkey, /* amount */ 10, /* seed */ 0, &alice_key),
+    ]);
+
+    let wallets = {
+        let snapshot = testkit.snapshot();
+        let schema = CurrencySchema::new(&snapshot);
+        (schema.wallet(&alice_pubkey), schema.wallet(&bob_pubkey))
+    };
+    if let (None, Some(bob_wallet)) = wallets {
+        assert_eq!(bob_wallet.balance(), 100);
+    } else {
+        panic!("Wallets not persisted")
+    }
+}
+
+#[test]
+fn test_transfer_to_nonexisting_wallet() {
+    let mut testkit = init_testkit();
+    let (alice_pubkey, alice_key) = crypto::gen_keypair();
+    let (bob_pubkey, bob_key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&alice_pubkey, "Alice", &alice_key),
+        TxTransfer::new(&alice_pubkey, &bob_pubkey, /* amount */ 10, /* seed */ 0, &alice_key),
+        // Although Bob's wallet is created, this occurs after the transfer is executed
+        TxCreateWallet::new(&bob_pubkey, "Bob", &bob_key),
+    ]);
+
+    let wallets = {
+        let snapshot = testkit.snapshot();
+        let schema = CurrencySchema::new(&snapshot);
+        (schema.wallet(&alice_pubkey), schema.wallet(&bob_pubkey))
+    };
+    if let (Some(alice_wallet), Some(bob_wallet)) = wallets {
+        assert_eq!(alice_wallet.balance(), 100);
+        assert_eq!(bob_wallet.balance(), 100);
+    } else {
+        panic!("Wallets not persisted")
+    }
+}
+
+#[test]
+fn test_transfer_overcharge() {
+    let mut testkit = init_testkit();
+    let (alice_pubkey, alice_key) = crypto::gen_keypair();
+    let (bob_pubkey, bob_key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&alice_pubkey, "Alice", &alice_key),
+        TxCreateWallet::new(&bob_pubkey, "Bob", &bob_key),
+        TxTransfer::new(&alice_pubkey, &bob_pubkey, /* amount */ 150, /* seed */ 0, &alice_key),
+    ]);
+
+    // The transfer amount is greater than what Alice has at her disposal, so
+    // the transfer should fail.
+    let wallets = {
+        let snapshot = testkit.snapshot();
+        let schema = CurrencySchema::new(&snapshot);
+        (schema.wallet(&alice_pubkey), schema.wallet(&bob_pubkey))
+    };
+    if let (Some(alice_wallet), Some(bob_wallet)) = wallets {
+        assert_eq!(alice_wallet.balance(), 100);
+        assert_eq!(bob_wallet.balance(), 100);
+    } else {
+        panic!("Wallets not persisted")
+    }
+}
+
+#[test]
+fn test_transfers_in_single_block() {
+    let mut testkit = init_testkit();
+    let (alice_pubkey, alice_key) = crypto::gen_keypair();
+    let (bob_pubkey, bob_key) = crypto::gen_keypair();
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&alice_pubkey, "Alice", &alice_key),
+        TxCreateWallet::new(&bob_pubkey, "Bob", &bob_key),
+    ]);
+
+    let tx_a_to_b = TxTransfer::new(
+        &alice_pubkey,
+        &bob_pubkey,
+        90, // amount
+        0, // seed
+        &alice_key,
+    );
+    let tx_b_to_a = TxTransfer::new(
+        &bob_pubkey,
+        &alice_pubkey,
+        120, // amount
+        0, // seed
+        &bob_key,
+    );
+
+    {
+        // See what happens if transactions are applied in an "incorrect" order.
+        // We use `TestKit::probe_all()` method for this.
+
+        let snapshot = testkit.probe_all(txvec![tx_b_to_a.clone(), tx_a_to_b.clone()]);
+        let schema = CurrencySchema::new(&snapshot);
+        assert_eq!(schema.wallet(&alice_pubkey).map(|w| w.balance()), Some(10));
+        assert_eq!(schema.wallet(&bob_pubkey).map(|w| w.balance()), Some(190));
+    }
+
+    testkit.create_block_with_transactions(txvec![tx_a_to_b, tx_b_to_a]);
+    let snapshot = testkit.snapshot();
+    let schema = CurrencySchema::new(&snapshot);
+    assert_eq!(schema.wallet(&alice_pubkey).map(|w| w.balance()), Some(130));
+    assert_eq!(schema.wallet(&bob_pubkey).map(|w| w.balance()), Some(70));
+}
+
+/// Generate random transactions to perform [fuzz testing][fuzz] of the service. The service
+/// should maintain invariants under all circumstances; e.g., the total amount of tokens
+/// in existence should depend only on the number of registered wallets.
+///
+/// [fuzz]: https://en.wikipedia.org/wiki/Fuzzing
+#[test]
+fn test_fuzz_transfers() {
+    use std::collections::BTreeSet;
+    use std::iter::FromIterator;
+    use rand::Rng;
+
+    const BLOCKS: usize = 50; // number of blocks to create
+    const MAX_TRANSACTIONS: usize = 20; // maximum number of transactions in a block
+
+    let mut rng = rand::thread_rng();
+
+    let mut testkit = init_testkit();
+    let alice_keys = crypto::gen_keypair();
+    let bob_keys = crypto::gen_keypair();
+    let keys = &[alice_keys.clone(), bob_keys.clone()];
+    testkit.create_block_with_transactions(txvec![
+        TxCreateWallet::new(&alice_keys.0, "Alice", &alice_keys.1),
+        TxCreateWallet::new(&bob_keys.0, "Bob", &bob_keys.1),
+    ]);
+
+    for _ in 0..BLOCKS {
+        let n_txs = rng.gen_range(0, MAX_TRANSACTIONS); // number of transactions in the block
+
+        let txs: Vec<Box<Transaction>> = (0..n_txs)
+            .map(|_| {
+                let (sender, receiver) = (rng.choose(keys).unwrap(), rng.choose(keys).unwrap());
+                let amount = rng.gen_range(0, 250);
+                TxTransfer::new(&sender.0, &receiver.0, amount, rng.next_u64(), &sender.1).into()
+            })
+            .collect();
+
+        testkit.create_block_with_transactions(txs);
+
+        // Test invariants that should be maintained during fuzz testing
+        let schema = CurrencySchema::new(testkit.snapshot());
+        let wallets = schema.wallets();
+        let wallets: Vec<_> = wallets.values().collect();
+        // There must be 2 wallets in the storage
+        assert_eq!(wallets.len(), 2);
+        // These wallets should belong to Alice and Bob
+        assert_eq!(
+            BTreeSet::from_iter(wallets.iter().map(Wallet::pub_key)),
+            BTreeSet::from_iter(vec![&alice_keys.0, &bob_keys.0])
+        );
+        // The total amount of funds should equal 200, no matter which transactions were executed
+        assert_eq!(wallets.iter().fold(0, |acc, w| acc + w.balance()), 200);
+    }
+}


### PR DESCRIPTION
This PR adds a separate bundle of tests for service business logic as per exonum/exonum-doc#143 discussion.

Ideally, I would like for this to be merged after #46 (you can see that I've cherry-picked e28679ba2c69c829552c979292d97697c370e806 from here to that PR). In this case, the `Cargo.lock` update commit would naturally be removed.